### PR TITLE
slide-8-container and -title changes

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -323,7 +323,7 @@ body {
 		}
 
 		.slide-7 {
-			
+
 		}
 
 		.slide-8 {
@@ -1119,16 +1119,16 @@ body {
 			color: #813e46;
 			font-weight: 700;
 		}
-		
+
 		.projectbox {
 			padding: 20px 24px;
-			
+
 			img {
 				max-width: 100%;
-				width: 260px; 
+				width: 260px;
 				height: 150px;
 			}
-			
+
 			p {
 				margin-top: 28px;
 			}
@@ -1176,7 +1176,7 @@ body {
 			padding: 10px;
 		}
 	}
-	
+
 	.text-slide-7 {
 		.slide-title {
 			color: #7D2A32;
@@ -1187,7 +1187,7 @@ body {
 			margin-left: 10vw;
 		}
 	}
-	
+
 	.text-slide-8 {
 		.slide-title {
 			color: #7D2A32;
@@ -1358,13 +1358,14 @@ body {
 .slide-8-container {
 	width: 600px;
 	position: absolute;
-	right: 5vw;
+	left: 50vw;
 	bottom: 40vh;
 }
 
 .slide-8-title {
 	font-size: 24px;
 	font-weight: 600;
+	color: #7d2a32;
 }
 
 .slide-8-bullet {


### PR DESCRIPTION
Hello! 
Made updates to slide 8 (external talks): 
 1. Subtitle text color changed to 7d2a32 (same as titles)
2. Changed container placement to ~match PDF
Please let me know if anything needs to be corrected.
JY