### PR TITLE
Give the carousel controls z-index priority

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -218,12 +218,12 @@ body {
 					opacity: 0;
 					transform: scale(0);
 					transition: opacity 1250ms, transform 1s cubic-bezier(.47,1.47,.77,1.05);
-					
+
 					&.in {
 						opacity: 1;
 						transform: scale(1);
 					}
-					
+
 					&.fade-out {
 						opacity: 0;
 					}
@@ -258,7 +258,7 @@ body {
 				left: 15vw;
 				right: 10vw;
 				bottom: @baseBackgroundHeight + 1vh;
-				
+
 				.speakerCloudsDark, .speakerCloudsLight {
 					position: absolute;
 				}
@@ -1327,6 +1327,7 @@ body {
 	height: 75px;
 	width: 51px;
 	opacity: 0.4;
+	z-index: 99;
 }
 
 .slide-change:hover {
@@ -1374,6 +1375,10 @@ body {
 		display: none;
 		width: 100%;
 	}
+}
+
+.carousel-controls {
+	z-index: 100;
 }
 
 .intro-text {


### PR DESCRIPTION
Fixes an issue in which certain browsers treated the background images as if they were above the carousel controls.