### PR TITLE
Move logo on slide 1 to the foreground

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -961,7 +961,7 @@ body {
 			right: 40px;
 			bottom: 40px;
 			transition: 300ms 500ms;
-			z-index:1;
+			z-index:4;
 		}
 		&__intro-text {
 			position:absolute;
@@ -1219,7 +1219,7 @@ body {
 			color: #813e46;
 			font-weight: 700;
 		}
-		
+
 		.slide-5-subtext {
 			width: 24vw;
 		}


### PR DESCRIPTION
Resolves a styling error in which the Code for Denver logo intended to be displayed in the corner of the first slide was hidden behind the background mountain layers.