### PR TITLE
Make text on slide 2 fade in and out, resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
 								service.
 							</p>
 							<p>
-								That is more than 4.###
+								It adds up to 4,311
 								hours. However, what that
 								really means is more is
 								recycled every year, better
@@ -511,7 +511,7 @@
                         $(".intro-light-cloud").fadeIn ();
 						break;
 					case 2:
-						$(".text-slide-2").show();
+						$(".text-slide-2").fadeIn();
 						$(".text-slide-2 h2").slideDown();
 						break;
 					case 3:
@@ -596,7 +596,7 @@
 						var animationTime = 800;
 						$(".text-slide-2 h2").slideUp(animationTime);
 						setTimeout(function() {
-							$(".text-slide-2").hide();
+							$(".text-slide-2").fadeOut();
 						}, animationTime);
 						$(".slide-2 .in").removeClass("in");
 						break;

--- a/styles.less
+++ b/styles.less
@@ -980,6 +980,7 @@ body {
 			width: 20%;
 			flex-basis: 20%;
 			padding-right: 2em;
+			padding-left: 2em;
 			color: white;
 		}
 		&__center-column {
@@ -1456,7 +1457,7 @@ body {
 			}
 		}
 	}
-	
+
 	.text-slide-12 {
 		.slide-title {
 			color: #7D2A32;


### PR DESCRIPTION
Resolves several styling, animation, and content issues pertinent to slide 2:

- The left carousel control was positioned over slide text at common screen widths. As both are white, this made the text potentially difficult to read.
- Text content of the slide would disappear and appear abruptly instead of fading in and out.
- Text on the slide was still using a placeholder "4.###" value.